### PR TITLE
Add PS Script for PIM Assignment Info

### DIFF
--- a/Get-PIMAssignmentInfo.ps1
+++ b/Get-PIMAssignmentInfo.ps1
@@ -1,0 +1,36 @@
+#region params
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$SubscriptionId
+)
+#endregion
+
+#region main
+$currentDir = $(Get-Location).Path
+$currentDT = Get-Date -Format "yyyy-MM-dd_HH-mm"
+$oFile = "$($currentDir)\PIMAssignmentInfo_$($currentDT).csv"
+
+$EligiblePIMData = @()
+
+$scope = "/subscriptions/$SubscriptionId"
+Write-Host "Getting PIM Eligible Assignments for $scope"
+$EligileAssignments = Get-AzRoleEligibilityScheduleInstance -Scope $scope
+
+foreach ($Role in $EligileAssignments) {
+    $upnData = ""
+    if ($Role.PrincipalType -eq "User") {
+        $upnData = $Role.PrincipalEmail
+    }
+    $PIMProperties = [pscustomobject]@{
+        scope  = $Role.Scope
+        type   = $Role.PrincipalType
+        role   = $Role.RoleDefinitionDisplayName
+        object = $Role.PrincipalDisplayName
+        upn    = $upnData
+    }
+    $EligiblePIMData += $PIMProperties
+}
+
+$EligiblePIMData | FT
+$EligiblePIMData | Export-Csv $oFile -NoClobber -Encoding ASCII -NoTypeInformation
+#endregion


### PR DESCRIPTION
Script is run using the syntax 
`Get-PIMAssignmentInfo.ps1 -SubscriptionId <subscriptionId>`
Results are saved to CSV file in the current directory with the naming schema  PIMAssignmentInfo_yyyy-MM-dd_HH-mm.csv